### PR TITLE
Rename clojure.java.math to clojure.math

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # cljs-math
-A ClojureScript port of [`clojure.java.math`](https://clojure.github.io/clojure/branch-master/clojure.java.math-api.html)
+A ClojureScript port of [`clojure.math`](https://clojure.github.io/clojure/branch-master/clojure.math-api.html)
 
 This can be included in `deps.edn` by adding the following entry to the `:deps` map:
 ```
 com.github.quoll/cljs-math {:git/tag "v0.1.3" :git/sha "39ad53c"}
 ```
 
-The prime focus on this library is correctness before performance. It matches `clojure.java.math` as closely as possible.
+The prime focus on this library is correctness before performance. It matches `clojure.math` as closely as possible.
 
 ## Testing
 Tests are run on both the JVM and through a connection to ClojureScript running on Node. For this reason, the file is `.cljc` rather than `.cljs`.


### PR DESCRIPTION
As per https://github.com/clojure/clojure/commit/304d7c6a81bd7d8511e9ef3d89dc199b1464afaa#diff-5eb591422fa0aacc6b979c85bb750d6dacae0776da2e6380b77dfa2ccf2f1da2